### PR TITLE
fix：修复导入的节点路径

### DIFF
--- a/src/components/AIChatDialog.vue
+++ b/src/components/AIChatDialog.vue
@@ -866,7 +866,7 @@ export default defineComponent({
           // 针对单个或多个节点创建不同的通知消息
           if (successCount === 1) {
             const node = registeredNodes[0];
-            notificationMessage.value = `节点 ${node.className} 已成功注册为 ${node.path}！使用"${node.path}"搜索可找到此节点`;
+            notificationMessage.value = `节点 ${node.className} 已成功注册为 custom/${node.path}！`;
           } else {
             notificationMessage.value = `成功注册了 ${successCount} 个节点！详见聊天窗口`;
           }

--- a/src/components/NodeManagerDialog.vue
+++ b/src/components/NodeManagerDialog.vue
@@ -229,7 +229,7 @@
                   </div>
                   <div class="import-note">
                     <span class="note-icon">ℹ️</span>
-                    系统将保留节点原定义的路径，仅在前面添加 import/ 前缀
+                    系统将保留节点原定义的路径，仅在前面添加 custom/ 前缀
                   </div>
                 </div>
               </div>
@@ -370,7 +370,7 @@ const extractClassNames = (code: string): string[] => {
 // 新增: 计算节点的源文件名
 const getSourceFilePath = (node: NodeDefinition): string => {
   // 处理内置节点
-  if (node.nodeType.startsWith('import/')) {
+  if (node.nodeType.startsWith('custom/')) {
     // 导入节点: 从nodeType提取文件路径部分
     const parts = node.nodeType.split('/');
     if (parts.length > 2) {
@@ -459,8 +459,7 @@ export default defineComponent({
       for (const nodeType of allRegisteredTypes) {
         // 排除已经在自定义节点中的节点
         if (!userCreatedNodes.some(node => node.nodeType === nodeType) &&
-          !nodeType.startsWith('custom/') &&
-          !nodeType.startsWith('import/')) {
+          !nodeType.startsWith('custom/')) {
 
           // Extract the class name directly from the nodeType path
           const nodeName = nodeType.split('/').pop() || ''
@@ -829,12 +828,12 @@ export default defineComponent({
     // 获取节点来源类型
     const getNodeSource = (node: NodeDefinition): 'imported' | 'builtin' | 'custom' => {
       // 检查节点类型路径前缀来确定来源
-      if (node.nodeType.startsWith('import/')) {
+      if (node.nodeType.startsWith('custom/')) {
         return 'imported'
       }
 
-      // 检查是否是自定义节点
-      if (node.nodeType.startsWith('custom/')) {
+      // 检查是否是自定义节点（老版本兼容）
+      if (node.nodeType.includes('custom')) {
         return 'custom'
       }
 
@@ -956,7 +955,7 @@ export default defineComponent({
           // 保留原始路径结构，包括子目录
           const parts = node.nodeType.split('/');
 
-          // 移除"import/"前缀
+          // 移除"custom/"前缀
           parts.shift();
 
           // 获取文件路径(排除最后的节点名称)

--- a/src/services/nodeGeneratorService.ts
+++ b/src/services/nodeGeneratorService.ts
@@ -22,7 +22,7 @@ const customNodes: Map<string, NodeDefinition> = new Map()
 const CUSTOM_NODES_METADATA_KEY = '_customNodeDefinitions'
 
 // 标准化的导入前缀
-const IMPORT_PREFIX = 'import/'
+const IMPORT_PREFIX = 'custom/'
 
 /**
  * 构建节点路径
@@ -224,12 +224,12 @@ function extractCategory(nodePath: string): string {
   let category = 'custom'
 
   // 尝试从路径中提取有意义的分类
-  if (parts.length > 2 && parts[0] === 'import') {
+  if (parts.length > 2 && parts[0] === 'custom') {
     // 使用路径中的第三段作为分类（如果存在）
     if (parts.length > 3) {
       category = parts[2]
     } else if (parts.length === 3) {
-      // 如果只有三段 (import/name/class)，那么使用name作为分类
+      // 如果只有三段 (custom/name/class)，那么使用name作为分类
       category = parts[1]
     }
   }
@@ -467,14 +467,14 @@ function parseNodeType(nodeType: string): { fileName: string; originalPath: stri
   let fileName = 'plugin'
   let originalPath = nodeType
 
-  // 检查是否以import/开头
+  // 检查是否以custom/开头
   if (nodeType.startsWith(IMPORT_PREFIX)) {
     // 分割路径，提取文件名
     const parts = nodeType.split('/')
     if (parts.length >= 3) {
-      // 至少: import/filename/nodename
+      // 至少: custom/filename/nodename
       fileName = parts[1]
-      // 重建原始路径 (不包括import/前缀和文件名)
+      // 重建原始路径 (不包括custom/前缀和文件名)
       originalPath = parts.slice(2).join('/')
     }
   }


### PR DESCRIPTION
…eGeneratorService: Changed node path prefixes from 'import/' to 'custom/' for consistency across components. Enhanced notification messages and refined category extraction logic to improve clarity and maintainability.